### PR TITLE
Add prefix field to chat completion messages

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -119,6 +119,9 @@ type ChatCompletionMessage struct {
 
 	// For Role=tool prompts this should be set to the ID given in the assistant's prior request to call a tool.
 	ToolCallID string `json:"tool_call_id,omitempty"`
+
+	// Messari custom fields
+	Prefix bool `json:"prefix"`
 }
 
 func (m ChatCompletionMessage) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
**Describe the change**
<!-- Please provide a clear and concise description of the changes you're proposing. Explain what problem it solves or what feature it adds. -->

Add the prefix field to the ChatCompletionMessage field in addition to the Message field.

**Provide OpenAI documentation link**
<!-- Provide a relevant API doc from https://platform.openai.com/docs/api-reference -->

**Describe your solution**
<!-- Describe how your changes address the problem or how they add the feature. This should include a brief description of your approach and any new libraries or dependencies you're using. -->

**Tests**
<!-- Briefly describe how you have tested these changes. If possible — please add integration tests. -->

**Additional context**
<!-- Add any other context or screenshots or logs about your pull request here. If the pull request relates to an open issue, please link to it. -->
