### PR TITLE
Type ChatCompletionRequest.Metadata as map[string]any

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -323,8 +323,11 @@ type ChatCompletionRequest struct {
 	Store bool `json:"store,omitempty"`
 	// Controls effort on reasoning for reasoning models. It can be set to "low", "medium", or "high".
 	ReasoningEffort string `json:"reasoning_effort,omitempty"`
-	// Metadata to store with the completion.
-	Metadata map[string]string `json:"metadata,omitempty"`
+	// Metadata to store with the completion. Uses map[string]any (aligning with
+	// the other request types in this fork) so list-valued keys like "tags" can
+	// be sent. LiteLLM expects metadata["tags"] to be a list and calls .copy() on
+	// it; a string value crashes its SpendLog payload creation.
+	Metadata map[string]any `json:"metadata,omitempty"`
 	// NoLog is a specific field for LiteLLM to disable logging.
 	NoLog bool `json:"no-log,omitempty"`
 	// Configuration for a predicted output.


### PR DESCRIPTION
## What
Change `ChatCompletionRequest.Metadata` from `map[string]string` to `map[string]any`, aligning it with every other request type in this fork (`assistant`, `batch`, `run`, `thread`, `vector_store` already use `map[string]any`). `ChatCompletionRequest` was the legacy outlier.

## Why
LiteLLM's `_get_request_tags` does `metadata.get("tags", []).copy()` — it expects `metadata["tags"]` to be a **list**. With `map[string]string`, callers were forced to send a comma-joined **string**, which crashes LiteLLM's standard-logging payload creation (`'str' object has no attribute 'copy'`) and **drops the request from spend logs**. `map[string]any` lets callers pass `[]string` for tags.

## Breaking change
Callers that build `map[string]string{...}` literals for this field must switch to `map[string]any{...}`. The Copilot side is updated in its companion PR.

## Release
Needs a tag after merge — next is **`v1.41.10`** (v1.41.9 already exists). Copilot's `go.mod` will point at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)