### PR TITLE
Add additive Tags []string to ChatCompletionRequest (revert Metadata map[string]any)

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -323,11 +323,13 @@ type ChatCompletionRequest struct {
 	Store bool `json:"store,omitempty"`
 	// Controls effort on reasoning for reasoning models. It can be set to "low", "medium", or "high".
 	ReasoningEffort string `json:"reasoning_effort,omitempty"`
-	// Metadata to store with the completion. Uses map[string]any (aligning with
-	// the other request types in this fork) so list-valued keys like "tags" can
-	// be sent. LiteLLM expects metadata["tags"] to be a list and calls .copy() on
-	// it; a string value crashes its SpendLog payload creation.
-	Metadata map[string]any `json:"metadata,omitempty"`
+	// Metadata to store with the completion.
+	Metadata map[string]string `json:"metadata,omitempty"`
+	// Tags is a LiteLLM-specific field for request tags (spend-log request_tags /
+	// tag-based routing). It is sent as a JSON array; do NOT put tags in
+	// metadata["tags"] as a string — LiteLLM's _get_request_tags calls .copy() on
+	// it and crashes its SpendLog payload creation, dropping the request from logs.
+	Tags []string `json:"tags,omitempty"`
 	// NoLog is a specific field for LiteLLM to disable logging.
 	NoLog bool `json:"no-log,omitempty"`
 	// Configuration for a predicted output.


### PR DESCRIPTION
## What
- **Revert** `ChatCompletionRequest.Metadata` back to `map[string]string` (undo the `map[string]any` retype shipped in **v1.41.10** / #16)
- **Add** a purely additive field: `Tags []string \`json:"tags,omitempty"\``

## Why the revert
Changing the **type** of `Metadata` breaks every `go-openai` consumer in a dependent module's build graph. A `replace github.com/sashabaranov/go-openai => messari/go-openai` (e.g. in copilot's `go.mod`) swaps this fork in for **all** transitive users — including ones that import vanilla upstream `sashabaranov/go-openai` with `map[string]string` (e.g. **`dwh-api-service`**). Those consumers then fail to compile, and they *can't* adopt `map[string]any` without breaking their own upstream-based builds.

## Why the additive field works
`Tags []string` is purely additive — `Metadata` stays `map[string]string`, so **no consumer breaks**. Callers send LiteLLM request tags as a top-level JSON array (`"tags": [...]`) instead of stuffing a comma-string into `metadata["tags"]`, which LiteLLM's `_get_request_tags` calls `.copy()` on and crashes (`'str' object has no attribute 'copy'`), dropping the request from spend logs.

## Release
Supersedes v1.41.10 — please tag **v1.41.11** after merge. Copilot's companion PR will point at it and set `req.Tags`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)