### PR TITLE
Add CacheControl field to ChatMessagePart

### DIFF
--- a/cache_control_test.go
+++ b/cache_control_test.go
@@ -1,0 +1,58 @@
+package openai_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+// TestChatMessagePartCacheControlMarshal verifies that a CacheControl breakpoint
+// on a MultiContent text part serializes into the OpenAI/LiteLLM wire format:
+//
+//	{"role":"system","content":[{"type":"text","text":"...","cache_control":{"type":"ephemeral"}}]}
+func TestChatMessagePartCacheControlMarshal(t *testing.T) {
+	msg := openai.ChatCompletionMessage{
+		Role: openai.ChatMessageRoleSystem,
+		MultiContent: []openai.ChatMessagePart{
+			{
+				Type:         openai.ChatMessagePartTypeText,
+				Text:         "stable system prompt",
+				CacheControl: &openai.CacheControl{Type: "ephemeral"},
+			},
+		},
+	}
+
+	b, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(b)
+	for _, want := range []string{
+		`"content":[`,
+		`"type":"text"`,
+		`"text":"stable system prompt"`,
+		`"cache_control":{"type":"ephemeral"}`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("marshaled message missing %q\n got: %s", want, got)
+		}
+	}
+}
+
+// TestChatMessagePartCacheControlOmitted verifies the field is omitted when unset,
+// so existing callers are unaffected.
+func TestChatMessagePartCacheControlOmitted(t *testing.T) {
+	msg := openai.ChatCompletionMessage{
+		Role:         openai.ChatMessageRoleSystem,
+		MultiContent: []openai.ChatMessagePart{{Type: openai.ChatMessagePartTypeText, Text: "hi"}},
+	}
+	b, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "cache_control") {
+		t.Errorf("cache_control should be omitted when unset, got: %s", string(b))
+	}
+}

--- a/chat.go
+++ b/chat.go
@@ -88,10 +88,23 @@ const (
 	ChatMessagePartTypeImageURL ChatMessagePartType = "image_url"
 )
 
+// CacheControl is an Anthropic-style cache-control breakpoint. When set on a
+// ChatMessagePart, LiteLLM uses it to drive provider prompt/context caching
+// (e.g. Anthropic ephemeral caching, Gemini cachedContents). Type is typically
+// "ephemeral"; TTL is optional (e.g. "1h").
+//
+// Messari custom type.
+type CacheControl struct {
+	Type string `json:"type"`
+	TTL  string `json:"ttl,omitempty"`
+}
+
 type ChatMessagePart struct {
 	Type     ChatMessagePartType  `json:"type,omitempty"`
 	Text     string               `json:"text,omitempty"`
 	ImageURL *ChatMessageImageURL `json:"image_url,omitempty"`
+	// CacheControl marks this part as a caching breakpoint for LiteLLM. Messari custom field.
+	CacheControl *CacheControl `json:"cache_control,omitempty"`
 }
 
 type ChatCompletionMessage struct {


### PR DESCRIPTION
## What
Adds an Anthropic-style `cache_control` breakpoint to `ChatMessagePart`:

```go
type CacheControl struct {
    Type string `json:"type"`          // e.g. "ephemeral"
    TTL  string `json:"ttl,omitempty"` // e.g. "1h"
}
// ChatMessagePart gains:
CacheControl *CacheControl `json:"cache_control,omitempty"`
```

## Why
Lets callers mark a content part for provider prompt/context caching. LiteLLM translates `cache_control` into the underlying provider call — Anthropic ephemeral caching and **Gemini `cachedContents`**. This is needed so Copilot can cache the stable system-prompt + tools block on Gemini calls (~90% off cached input).

## Safety
- Purely **additive** and `omitempty` — existing callers and serialization are unchanged (test included for the omitted case).
- `MultiContent` already serializes as the `content` array via `ChatCompletionMessage.MarshalJSON`; `ChatMessagePart` uses default marshaling, so the new field flows through with no marshaler changes.

## Test
`cache_control_test.go` asserts the wire format:
`{"role":"system","content":[{"type":"text","text":"...","cache_control":{"type":"ephemeral"}}]}`
and that the field is omitted when unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)